### PR TITLE
name handling for checkboxes

### DIFF
--- a/zmultiselect/zurb5-multiselect.js
+++ b/zmultiselect/zurb5-multiselect.js
@@ -173,7 +173,7 @@ var methods = {
                 else                          appendTo = '#'+id+' ul div.optgroup_'+optgroup_id;
                     
                     
-                $(appendTo).append("<li "+disabledClass+"><input value='"+$(z).val()+"' type='checkbox' name="+checkboxesName+" "+checke    d+" "+disabled+" "+dataZ+" />&nbsp;"+$(z).text()+"</li>");
+                $(appendTo).append("<li "+disabledClass+"><input value='"+$(z).val()+"' type='checkbox' name="+checkboxesName+" "+checked+" "+disabled+" "+dataZ+" />&nbsp;"+$(z).text()+"</li>");
                 
                 if(optgroup_size === j+1){
                     optgroup_size = 0;


### PR DESCRIPTION
Checkboxes generated now gets a name based on the initial name of the select (which is removed from it by the way).
For example, <select name="test"> will generated checkboxes like this :
<input type="checkbox" name="test[]" />
