### PR TITLE
Triggering default select change on update

### DIFF
--- a/zmultiselect/zurb5-multiselect.js
+++ b/zmultiselect/zurb5-multiselect.js
@@ -264,12 +264,13 @@ var methods = {
             $.each(container.find('input:checkbox'), function(k, v) {
                 if($(v).val() !== undefined){
                     if($(v).prop('checked')) {
-                        select.find("option[value='"+$(v).val()+"']").attr("selected", true);
+                        select.find("option[value='"+$(v).val()+"']").prop("selected", true);
                     } else {
-                        select.find("option[value='"+$(v).val()+"']").attr("selected", false);
+                        select.find("option[value='"+$(v).val()+"']").prop("selected", false);
                     }
                 }
             });
+            select.trigger('change');
         });
 
         onResize();


### PR DESCRIPTION
Changing "attr" to "prop" when updating the initial select's options (was otherwise triggering only once).
Also added a line to trigger the change on the initial select to allow for some event handling on it.
