### PR TITLE
fixing options

### DIFF
--- a/zmultiselect/zurb5-multiselect.js
+++ b/zmultiselect/zurb5-multiselect.js
@@ -101,7 +101,7 @@
 
 var methods = {
     init : function(options) {
-        
+        var options = options || {};
         var id,checked,disabled="",disabledClass="";
         var optgroup=[];
         var optgroup_size,optgroup_id = 0;


### PR DESCRIPTION
fixing to set options to an empty object if not provided. This fixes an issue that requires you to pass an empty object to the method to prevent it erroring when trying to access properties on options
