### PR TITLE
call refreshPlaceholder during init phase

### DIFF
--- a/zmultiselect/zurb5-multiselect.js
+++ b/zmultiselect/zurb5-multiselect.js
@@ -202,6 +202,7 @@ var methods = {
                 
             });
             $('#'+id+' span.zmshead').html( (options.placeholder===undefined) ? '&nbsp;' : options.placeholder );
+            refreshPlaceholder(id,options.placeholder,options.selectedText);
         });
         
         if(options.filter === true){


### PR DESCRIPTION
On start, if some values are selected We see placeholder text instead of
selectedText property.

If we open your demo (index.html), you see that ZMultiSelect Box #1 have placeholder "My pretty zurb multiselect" instead "Selected 1 of 10".  This fixes it.